### PR TITLE
[S] Allow model name change if mapped table name is the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Default to mapped table name instead of model name for identifying prisma models.  
+
 ## 0.0.4 (2023-08-23)
 
 - Add support for reading prisma schema configuration from `package.json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Default to mapped table name instead of model name for identifying prisma models.  
+- Use mapped table name (when present) to match old and new models for detecting changes.
 
 ## 0.0.4 (2023-08-23)
 

--- a/src/prisma-safety.test.ts
+++ b/src/prisma-safety.test.ts
@@ -47,7 +47,7 @@ describe('prisma safety', () => {
         expect(listSafetyIssuesBasedOnSchemas(prev, current).length).toBe(1);
       });
 
-      it('disallows schema name change if the mapped table name is not the same', () => {
+      it('disallows model name change if the mapped table name is not the same', () => {
         const prev = getSchema(`
           model Foo {
             qid String @id

--- a/src/prisma-safety.test.ts
+++ b/src/prisma-safety.test.ts
@@ -64,6 +64,24 @@ describe('prisma safety', () => {
         `);
         expect(listSafetyIssuesBasedOnSchemas(prev, current).length).toBe(1);
       });
+
+      it('disallows field name change if missing ignore and the mapped table name is the same', () => {
+        const prev = getSchema(`
+          model Foo {
+            qid String @id
+            bar String @map(name: "bar")
+            @@map(name: "foo")
+          }
+        `);
+        const current = getSchema(`
+          model Bar {
+            qid String @id
+            baz String @map(name: "bar")
+            @@map(name: "foo")
+          }
+        `);
+        expect(listSafetyIssuesBasedOnSchemas(prev, current).length).toBe(1);
+      });
     });
 
     describe('safe', () => {
@@ -176,6 +194,24 @@ describe('prisma safety', () => {
           model Bar {
             qid String @id
             bar String @map(name: "bar")
+            @@map(name: "foo")
+          }
+        `);
+        expect(listSafetyIssuesBasedOnSchemas(prev, current).length).toBe(0);
+      });
+
+      it('allows field name change with ignore and the mapped table name is the same', () => {
+        const prev = getSchema(`
+          model Foo {
+            qid String @id
+            bar String @map(name: "bar") @ignore
+            @@map(name: "foo")
+          }
+        `);
+        const current = getSchema(`
+          model Bar {
+            qid String @id
+            baz String @map(name: "bar")
             @@map(name: "foo")
           }
         `);

--- a/src/prisma-safety.test.ts
+++ b/src/prisma-safety.test.ts
@@ -182,7 +182,7 @@ describe('prisma safety', () => {
         expect(listSafetyIssuesBasedOnSchemas(prev, current).length).toBe(0);
       });
 
-      it('allows schema name change if the mapped table name is the same', () => {
+      it('allows model name change if the mapped table name is the same', () => {
         const prev = getSchema(`
           model Foo {
             qid String @id

--- a/src/prisma-safety.test.ts
+++ b/src/prisma-safety.test.ts
@@ -46,6 +46,24 @@ describe('prisma safety', () => {
         `);
         expect(listSafetyIssuesBasedOnSchemas(prev, current).length).toBe(1);
       });
+
+      it('disallows schema name change if the mapped table name is not the same', () => {
+        const prev = getSchema(`
+          model Foo {
+            qid String @id
+            bar String @map(name: "bar")
+            @@map(name: "foo")
+          }
+        `);
+        const current = getSchema(`
+          model Bar {
+            qid String @id
+            bar String @map(name: "bar")
+            @@map(name: "bar")
+          }
+        `);
+        expect(listSafetyIssuesBasedOnSchemas(prev, current).length).toBe(1);
+      });
     });
 
     describe('safe', () => {
@@ -141,6 +159,24 @@ describe('prisma safety', () => {
           model Foo {
             qid String @id
             bar String @map(name: "bar")
+          }
+        `);
+        expect(listSafetyIssuesBasedOnSchemas(prev, current).length).toBe(0);
+      });
+
+      it('allows schema name change if the mapped table name is the same', () => {
+        const prev = getSchema(`
+          model Foo {
+            qid String @id
+            bar String @map(name: "bar")
+            @@map(name: "foo")
+          }
+        `);
+        const current = getSchema(`
+          model Bar {
+            qid String @id
+            bar String @map(name: "bar")
+            @@map(name: "foo")
           }
         `);
         expect(listSafetyIssuesBasedOnSchemas(prev, current).length).toBe(0);

--- a/src/prisma-safety.ts
+++ b/src/prisma-safety.ts
@@ -9,7 +9,7 @@ import {
   type BlockAttribute,
   type Schema,
   getSchema,
-  KeyValue,
+  type KeyValue,
 } from '@mrleebo/prisma-ast';
 
 type SafetyIssue = {

--- a/src/prisma-safety.ts
+++ b/src/prisma-safety.ts
@@ -153,13 +153,11 @@ function tablesFromSchema(schema: Schema): Map<string, Model> {
   const tables = new Map();
   for (const block of schema.list) {
     if (block.type === 'model') {
-      const tableName = getMappedTableName(block);
-      // Prefer mapped name as table identifier if it exists.
-      if (tableName) {
-        tables.set(tableName, block);
-      } else {
-        tables.set(block.name, block);
-      }
+      const mappedName = getMappedTableName(block);
+      // For safety considerations, what matters is the actual table
+      // name, not the model name (used for generated code).
+      const tableName = mappedName ?? block.name;
+      tables.set(tableName, block);
     }
   }
 


### PR DESCRIPTION
We want prisma-safety to allow the use case where we change a prisma model name but maintain the same db mapping. In this case, a db table is not being deleted or created.