### PR TITLE
Add Renovate configuration with auto-merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "timezone": "America/Los_Angeles",
+  "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
+  "stabilityDays": 3,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": ">=1.0.0",
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds Renovate configuration for automated dependency updates
- Enables auto-merge for minor/patch updates (packages >=1.0.0 only)
- Excludes 0.x packages from auto-merge since they don't follow strict semver
- Schedule: weekday nights (10pm-5am PT) and weekends
- 3-day stability period before auto-merge

## Test plan
- [ ] Verify Renovate dashboard appears after merge
- [ ] Confirm auto-merge works for a test dependency update

🤖 Generated with [Claude Code](https://claude.com/claude-code)